### PR TITLE
feat(docker): Refactor dev workspace for core services (AMA-517)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,85 @@
-# Supabase
+# =============================================================================
+# AmakaFlow Dev Workspace - Environment Variables
+# =============================================================================
+# Copy to .env and fill in your values: cp .env.example .env
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# DATABASE (Required)
+# -----------------------------------------------------------------------------
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your_anon_key
-SUPABASE_SERVICE_KEY=your_service_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 
-# Clerk
+# Direct Postgres connection (calendar-api)
+DATABASE_URL=postgresql://postgres:password@host:6543/postgres
+
+# -----------------------------------------------------------------------------
+# AUTHENTICATION (Required)
+# -----------------------------------------------------------------------------
 CLERK_PUBLISHABLE_KEY=pk_test_your_key
 CLERK_SECRET_KEY=sk_test_your_key
+CLERK_DOMAIN=your-domain.clerk.accounts.dev
 
-# YouTube Transcript API
+# -----------------------------------------------------------------------------
+# AI SERVICES (Required for chat-api, workout-ingestor)
+# -----------------------------------------------------------------------------
+OPENAI_API_KEY=sk-your-openai-key
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
+
+# Default model for chat-api
+DEFAULT_MODEL=claude-sonnet-4-20250514
+
+# -----------------------------------------------------------------------------
+# AI OBSERVABILITY (Optional)
+# -----------------------------------------------------------------------------
+HELICONE_API_KEY=
+HELICONE_ENABLED=false
+
+# -----------------------------------------------------------------------------
+# ERROR TRACKING (Optional)
+# -----------------------------------------------------------------------------
+SENTRY_DSN=
+
+# -----------------------------------------------------------------------------
+# TTS - Text to Speech (Optional, chat-api)
+# -----------------------------------------------------------------------------
+ELEVENLABS_API_KEY=
+TTS_ENABLED=false
+TTS_DEFAULT_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+TTS_DAILY_CHAR_LIMIT=50000
+
+# -----------------------------------------------------------------------------
+# RATE LIMITS (chat-api)
+# -----------------------------------------------------------------------------
+RATE_LIMIT_FREE=50
+RATE_LIMIT_PAID=500
+
+# -----------------------------------------------------------------------------
+# INTERNAL API (service-to-service)
+# -----------------------------------------------------------------------------
+INTERNAL_API_KEY=your-internal-api-key
+
+# CORS origins (comma-separated)
+ALLOWED_ORIGINS=http://localhost:3000
+
+# -----------------------------------------------------------------------------
+# VIDEO/AUDIO TRANSCRIPTION (workout-ingestor)
+# -----------------------------------------------------------------------------
 YT_TRANSCRIPT_API_TOKEN=
 
-# OpenAI (optional but recommended)
-OPENAI_API_KEY=
+# Deepgram (optional)
+DEEPGRAM_API_KEY=
 
-# Anthropic (optional alternative)
-ANTHROPIC_API_KEY=
+# AssemblyAI (optional)
+ASSEMBLYAI_API_KEY=
 
-# Garmin (optional)
-GARMIN_EMAIL=
-GARMIN_PASSWORD=
-GARMIN_UNOFFICIAL_SYNC_ENABLED=false
+# -----------------------------------------------------------------------------
+# ENVIRONMENT
+# -----------------------------------------------------------------------------
+ENVIRONMENT=development
 
-# Strava (optional)
-STRAVA_CLIENT_ID=
-STRAVA_CLIENT_SECRET=
+# -----------------------------------------------------------------------------
+# TESTING (dev/staging only - never set in production)
+# -----------------------------------------------------------------------------
+# TEST_AUTH_SECRET=your-secure-random-string

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,26 @@
 # Environment
 .env
 .env.local
+.env.save
 *.env
 
-# Cloned service repos (actual code)
+# Service repositories (cloned separately)
 amakaflow-ui/
-workout-ingestor-api/
+chat-api/
 mapper-api/
-strava-sync-api/
 calendar-api/
+workout-ingestor-api/
+
+# Other project folders (not part of core monorepo)
+strava-sync-api/
 garmin-sync-api/
 garmin-usb-fit-api/
+garmin-exercise-data/
+amakaflow-fitfiletool/
+amakaflow-db/
 
-# Symlinks to services
-ui
-workout-ingestor-api
-mapper-api
-strava-sync-api
-calendar-api
-garmin-sync-api
-garmin-usb-fit-api
+# Supabase local (if created)
+supabase/
 
 # Python
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,65 @@
-.PHONY: help setup start stop restart logs clean
+.PHONY: help setup start stop restart logs clean build status \
+        ui chat mapper calendar ingestor \
+        logs-ui logs-chat logs-mapper logs-calendar logs-ingestor
+
+# =============================================================================
+# MAIN COMMANDS
+# =============================================================================
 
 help:
-	@echo "AmakaFlow Workspace Commands"
+	@echo "AmakaFlow Dev Workspace"
 	@echo ""
-	@echo "  make setup    - Initial setup (create .env, build images)"
-	@echo "  make start    - Start all services"
-	@echo "  make stop     - Stop all services"
-	@echo "  make restart  - Restart all services"
-	@echo "  make logs     - View logs"
-	@echo "  make clean    - Clean up containers and volumes"
+	@echo "Setup:"
+	@echo "  make setup      - Initial setup (create .env, build images)"
+	@echo "  make build      - Rebuild all images"
+	@echo ""
+	@echo "Running:"
+	@echo "  make start      - Start all services"
+	@echo "  make stop       - Stop all services"
+	@echo "  make restart    - Restart all services"
+	@echo "  make status     - Show service status"
+	@echo ""
+	@echo "Logs:"
+	@echo "  make logs       - View all logs"
+	@echo "  make logs-ui    - View UI logs"
+	@echo "  make logs-chat  - View chat-api logs"
+	@echo "  make logs-mapper    - View mapper-api logs"
+	@echo "  make logs-calendar  - View calendar-api logs"
+	@echo "  make logs-ingestor  - View workout-ingestor logs"
+	@echo ""
+	@echo "Individual Services:"
+	@echo "  make ui         - Start only UI"
+	@echo "  make chat       - Start only chat-api"
+	@echo "  make mapper     - Start only mapper-api"
+	@echo "  make calendar   - Start only calendar-api"
+	@echo "  make ingestor   - Start only workout-ingestor"
+	@echo ""
+	@echo "Cleanup:"
+	@echo "  make clean      - Stop and remove containers/volumes"
 
 setup:
-	@test -f .env || (cp .env.example .env && echo "⚠️  Created .env - edit with your API keys!")
+	@test -f .env || (cp .env.example .env && echo "Created .env - edit with your API keys!")
 	@docker compose build
-	@echo "✅ Setup complete!"
+	@echo ""
+	@echo "Setup complete!"
+	@echo "Edit .env with your API keys, then run: make start"
+
+build:
+	@docker compose build --no-cache
 
 start:
 	@docker compose up -d
-	@echo "✅ Services started!"
+	@echo ""
+	@echo "Services starting..."
 	@echo ""
 	@echo "URLs:"
-	@echo "  UI:          http://localhost:3000"
-	@echo "  Ingestor:    http://localhost:8004/docs"
-	@echo "  Mapper:      http://localhost:8001/docs"
-	@echo "  Strava:      http://localhost:8000/docs"
-	@echo "  Calendar:    http://localhost:8003/docs"
+	@echo "  UI:        http://localhost:3000"
+	@echo "  Chat:      http://localhost:8005/docs"
+	@echo "  Mapper:    http://localhost:8001/docs"
+	@echo "  Calendar:  http://localhost:8003/docs"
+	@echo "  Ingestor:  http://localhost:8004/docs"
+	@echo ""
+	@echo "Run 'make logs' to view logs or 'make status' to check health"
 
 stop:
 	@docker compose down
@@ -32,10 +67,57 @@ stop:
 restart:
 	@docker compose restart
 
+status:
+	@docker compose ps
+
 logs:
 	@docker compose logs -f
 
 clean:
-	@docker compose down -v
+	@docker compose down -v --remove-orphans
+	@echo "Cleaned up containers and volumes"
+
+# =============================================================================
+# INDIVIDUAL SERVICE COMMANDS
+# =============================================================================
+
+ui:
+	@docker compose up -d ui
+	@echo "UI started at http://localhost:3000"
+
+chat:
+	@docker compose up -d chat
+	@echo "Chat API started at http://localhost:8005/docs"
+
+mapper:
+	@docker compose up -d mapper
+	@echo "Mapper API started at http://localhost:8001/docs"
+
+calendar:
+	@docker compose up -d calendar
+	@echo "Calendar API started at http://localhost:8003/docs"
+
+ingestor:
+	@docker compose up -d workout-ingestor
+	@echo "Workout Ingestor started at http://localhost:8004/docs"
+
+# =============================================================================
+# PER-SERVICE LOGS
+# =============================================================================
+
+logs-ui:
+	@docker compose logs -f ui
+
+logs-chat:
+	@docker compose logs -f chat
+
+logs-mapper:
+	@docker compose logs -f mapper
+
+logs-calendar:
+	@docker compose logs -f calendar
+
+logs-ingestor:
+	@docker compose logs -f workout-ingestor
 
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -1,71 +1,120 @@
-# AmakaFlow Workspace
+# AmakaFlow Dev Workspace
 
-Workout content transformation and synchronization platform.
+Workout content transformation and AI coaching platform.
 
 ## Quick Start
 
 ```bash
-# Setup
+# 1. Setup (creates .env, builds images)
 make setup
 
-# Edit .env with your API keys
+# 2. Edit .env with your API keys
 nano .env
 
-# Start services
+# 3. Start all services
 make start
 
-# View logs
+# 4. View logs
 make logs
-```
-
-## Structure
-
-```
-amakaflow-dev-workspace/
-├── docker-compose.yml       # Service orchestration
-├── .env                     # Environment (gitignored)
-├── Makefile                 # Dev commands
-│
-├── amakaflow-ui/            # UI repo (cloned)
-├── workout-ingestor-api/    # Ingestor repo (cloned)
-├── mapper-api/              # Mapper repo (cloned)
-├── strava-sync-api/         # Strava repo (cloned)
-├── calendar-api/            # Calendar repo (cloned)
-├── garmin-sync-api/         # Garmin repo (cloned)
-├── garmin-usb-fit-api/      # USB FIT repo (cloned)
-│
-└── ui → amakaflow-ui        # Symlink for docker-compose
-    workout-ingestor-api → ... # Symlinks for docker-compose
-    etc...
 ```
 
 ## Services
 
-- **UI** (3000): React frontend
-- **Ingestor** (8004): YouTube/OCR/text parsing
-- **Mapper** (8001): Exercise normalization
-- **Strava** (8000): Strava OAuth sync
-- **Calendar** (8003): Calendar events
-- **Garmin Sync** (8002): Garmin Connect (optional)
-- **USB FIT** (8095): FIT file generation (optional)
+| Port | Service | Description |
+|------|---------|-------------|
+| 3000 | **UI** | React/Vite frontend |
+| 8005 | **Chat API** | AI conversation service |
+| 8001 | **Mapper API** | Exercise mapping & normalization |
+| 8003 | **Calendar API** | Calendar integration |
+| 8004 | **Workout Ingestor** | Video/OCR/text parsing |
 
-## Development
+## Project Structure
+
+```
+amakaflow-dev-workspace/
+├── docker-compose.yml          # Service orchestration
+├── docker-compose.override.yml # Dev overrides (hot reload)
+├── .env                        # Environment vars (gitignored)
+├── .env.example                # Template for .env
+├── Makefile                    # Dev commands
+│
+├── amakaflow-ui/               # Frontend (React/Vite)
+├── chat-api/                   # AI chat service (FastAPI)
+├── mapper-api/                 # Exercise mapping (FastAPI)
+├── calendar-api/               # Calendar service (FastAPI)
+├── workout-ingestor-api/       # Video/OCR ingestion (FastAPI)
+│
+├── amakaflow-db/               # Database migrations (separate repo)
+├── amakaflow-fitfiletool/      # Shared Python package
+│
+└── .claude/                    # Claude Code configuration
+    ├── agents/                 # Custom AI agents
+    └── skills/                 # Development skills
+```
+
+## Development Commands
 
 ```bash
-make start    # Start all services
-make stop     # Stop all services
-make logs     # View logs
-make restart  # Restart services
-make clean    # Clean up everything
+# Full stack
+make start      # Start all services
+make stop       # Stop all services
+make restart    # Restart all services
+make status     # Show service status
+make logs       # View all logs
+make clean      # Remove containers and volumes
+
+# Individual services
+make ui         # Start only UI
+make chat       # Start only chat-api
+make mapper     # Start only mapper-api
+make calendar   # Start only calendar-api
+make ingestor   # Start only workout-ingestor
+
+# Per-service logs
+make logs-ui
+make logs-chat
+make logs-mapper
+make logs-calendar
+make logs-ingestor
+
+# Rebuild
+make build      # Rebuild all images
 ```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and configure:
+
+**Required:**
+- `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+- `CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `CLERK_DOMAIN`
+- `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY`
+
+**Optional:**
+- `HELICONE_API_KEY` - AI observability
+- `ELEVENLABS_API_KEY` - Text-to-speech
+- `SENTRY_DSN` - Error tracking
+
+See `.env.example` for full list with descriptions.
+
+## Hot Reload
+
+Development hot reload is enabled by default via `docker-compose.override.yml`:
+- UI: Vite HMR
+- APIs: Uvicorn `--reload`
+
+Changes to source files automatically reload without container restart.
 
 ## Updating Services
 
 ```bash
-# Update a specific service
-cd workout-ingestor-api
-git pull
-cd ..
-docker-compose build workout-ingestor
-docker-compose restart workout-ingestor
+# Update and rebuild a specific service
+cd chat-api && git pull && cd ..
+docker compose build chat
+docker compose restart chat
 ```
+
+## Related Repositories
+
+- [amakaflow-db](https://github.com/supergeri/amakaflow-db) - Database migrations
+- [amakaflow-fitfiletool](https://github.com/supergeri/amakaflow-fitfiletool) - FIT file utilities

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,30 @@
+# Development overrides - automatically loaded with docker-compose.yml
+# Enables hot reload via volume mounts
+
+services:
+  ui:
+    volumes:
+      - ./amakaflow-ui:/app
+      - /app/node_modules
+    command: npm run dev -- --host 0.0.0.0
+
+  chat:
+    volumes:
+      - ./chat-api:/app
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8005 --reload
+
+  mapper:
+    volumes:
+      - ./mapper-api:/app
+      - ./amakaflow-fitfiletool:/amakaflow-fitfiletool:ro
+    command: uvicorn backend.app:app --host 0.0.0.0 --port 8001 --reload
+
+  calendar:
+    volumes:
+      - ./calendar-api:/app
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8003 --reload
+
+  workout-ingestor:
+    volumes:
+      - ./workout-ingestor-api:/app
+    command: uvicorn workout_ingestor_api.main:app --host 0.0.0.0 --port 8004 --reload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,13 @@
-version: '3.8'
-
 services:
-  # UI - React frontend
+  # =============================================================================
+  # FRONTEND
+  # =============================================================================
   ui:
     build:
-      context: ./ui
+      context: ./amakaflow-ui
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - ./ui:/app
-      - /app/node_modules
     env_file:
       - .env
     environment:
@@ -18,37 +15,71 @@ services:
       - VITE_SUPABASE_URL=${SUPABASE_URL}
       - VITE_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
       - VITE_CLERK_PUBLISHABLE_KEY=${CLERK_PUBLISHABLE_KEY}
+      - VITE_MAPPER_API_URL=http://localhost:8001
+      - VITE_INGESTOR_API_URL=http://localhost:8004
+      - VITE_CALENDAR_API_URL=http://localhost:8003
+      - VITE_CHAT_API_URL=http://localhost:8005
+      - VITE_CHAT_ENABLED=true
     networks:
       - amakaflow
     depends_on:
-      - workout-ingestor
-      - mapper
+      chat:
+        condition: service_healthy
+      mapper:
+        condition: service_started
+      calendar:
+        condition: service_started
+      workout-ingestor:
+        condition: service_started
 
-  # Workout Ingestor
-  workout-ingestor:
+  # =============================================================================
+  # CORE APIs
+  # =============================================================================
+
+  # Chat API - AI conversation service
+  chat:
     build:
-      context: ./workout-ingestor-api
+      context: ./chat-api
       dockerfile: Dockerfile
     ports:
-      - "8004:8004"
-    volumes:
-      - ./workout-ingestor-api:/app
+      - "8005:8005"
     env_file:
       - .env
     environment:
       - PYTHONUNBUFFERED=1
+      - ENVIRONMENT=development
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - CLERK_DOMAIN=${CLERK_DOMAIN}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - HELICONE_API_KEY=${HELICONE_API_KEY}
+      - HELICONE_ENABLED=${HELICONE_ENABLED:-false}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}
+      - INTERNAL_API_KEY=${INTERNAL_API_KEY}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-20250514}
+      - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
+      - TTS_ENABLED=${TTS_ENABLED:-false}
+      - TTS_DEFAULT_VOICE_ID=${TTS_DEFAULT_VOICE_ID}
+      - TTS_DAILY_CHAR_LIMIT=${TTS_DAILY_CHAR_LIMIT:-50000}
+      - RATE_LIMIT_FREE=${RATE_LIMIT_FREE:-50}
+      - RATE_LIMIT_PAID=${RATE_LIMIT_PAID:-500}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8005/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     networks:
       - amakaflow
 
-  # Mapper
+  # Mapper API - Exercise mapping service
   mapper:
     build:
       context: ./mapper-api
       dockerfile: Dockerfile
     ports:
       - "8001:8001"
-    volumes:
-      - ./mapper-api:/app
     env_file:
       - .env
     environment:
@@ -56,89 +87,79 @@ services:
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - INGESTOR_URL=http://workout-ingestor:8004
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     networks:
       - amakaflow
 
-  # Strava Sync
-  strava:
-    build:
-      context: ./strava-sync-api
-      dockerfile: Dockerfile
-    ports:
-      - "8000:8000"
-    volumes:
-      - ./strava-sync-api:/app
-    env_file:
-      - .env
-    environment:
-      - PYTHONUNBUFFERED=1
-      - SUPABASE_URL=${SUPABASE_URL}
-      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-    networks:
-      - amakaflow
-
-  # Calendar API
+  # Calendar API - Calendar integration service
   calendar:
     build:
       context: ./calendar-api
       dockerfile: Dockerfile
     ports:
       - "8003:8003"
-    volumes:
-      - ./calendar-api:/app
     env_file:
       - .env
     environment:
       - PYTHONUNBUFFERED=1
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+      - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     networks:
       - amakaflow
 
-  # Garmin Sync (optional)
-  garmin-sync:
+  # Workout Ingestor API - Video/OCR ingestion service
+  workout-ingestor:
     build:
-      context: ./garmin-sync-api
+      context: ./workout-ingestor-api
       dockerfile: Dockerfile
     ports:
-      - "8002:8002"
-    volumes:
-      - ./garmin-sync-api:/app
+      - "8004:8004"
     env_file:
       - .env
     environment:
       - PYTHONUNBUFFERED=1
-      - GARMIN_UNOFFICIAL_SYNC_ENABLED=${GARMIN_UNOFFICIAL_SYNC_ENABLED:-false}
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+      - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - HELICONE_API_KEY=${HELICONE_API_KEY}
+      - HELICONE_ENABLED=${HELICONE_ENABLED:-false}
+      - YT_TRANSCRIPT_API_TOKEN=${YT_TRANSCRIPT_API_TOKEN}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8004/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     networks:
       - amakaflow
-    profiles:
-      - full
-
-  # Garmin USB FIT (optional)
-  garmin-usb-fit:
-    build:
-      context: ./garmin-usb-fit-api
-      dockerfile: Dockerfile
-    ports:
-      - "8095:8095"
-    volumes:
-      - ./garmin-usb-fit-api:/app
-    env_file:
-      - .env
-    environment:
-      - PYTHONUNBUFFERED=1
-    networks:
-      - amakaflow
-    profiles:
-      - full
 
 networks:
   amakaflow:
     driver: bridge
 
-# Usage:
-# Start core services: docker-compose up -d
-# Start all services: docker-compose --profile full up -d
-# View logs: docker-compose logs -f
-# Stop: docker-compose down
+# =============================================================================
+# USAGE
+# =============================================================================
+# Start all services:     docker compose up -d
+# Start with logs:        docker compose up
+# View logs:              docker compose logs -f [service]
+# Stop all:               docker compose down
+# Rebuild:                docker compose build --no-cache
+# =============================================================================


### PR DESCRIPTION
## Summary

Refactors the Docker setup to focus on the 5 core services needed for local development and testing.

### Core Services (IN SCOPE)
| Port | Service | Status |
|------|---------|--------|
| 3000 | amakaflow-ui | Fixed path |
| 8005 | chat-api | **NEW** (was missing) |
| 8001 | mapper-api | OK |
| 8003 | calendar-api | OK |
| 8004 | workout-ingestor-api | OK |

### Changes

**docker-compose.yml:**
- Fixed UI context path (`./ui` → `./amakaflow-ui`)
- Added chat-api service with healthcheck
- Removed strava/garmin services (out of scope for dev workspace)
- Added healthchecks to all services
- Added proper `depends_on` with health conditions

**docker-compose.override.yml:** (NEW)
- Volume mounts for hot reload
- Uvicorn `--reload` flags for APIs
- Vite HMR for UI

**.env.example:**
- Consolidated all required variables
- Organized by category (DB, Auth, AI, TTS, etc.)
- Added missing vars: `CLERK_DOMAIN`, `INTERNAL_API_KEY`, TTS settings

**Makefile:**
- Added per-service commands (`make chat`, `make mapper`, etc.)
- Added per-service logs (`make logs-chat`, etc.)
- Added `make status` and `make build`
- Removed references to out-of-scope services

**README.md:**
- Updated with current 5-service structure
- Clear setup instructions
- All make commands documented

**Cleanup:**
- Removed empty `supabase/` folder
- Updated `.gitignore`

## Test Plan
- [ ] `docker compose config` validates
- [ ] `make setup` creates .env and builds images
- [ ] `make start` brings up all 5 services
- [ ] Services accessible at documented ports
- [ ] Hot reload works (code changes reflect without restart)

## Linear
Closes AMA-517

🤖 Generated with [Claude Code](https://claude.com/claude-code)