### PR TITLE
fix(ci): fix grep crash in validate-ticket checkbox check

### DIFF
--- a/.github/workflows/validate-ticket.yml
+++ b/.github/workflows/validate-ticket.yml
@@ -73,7 +73,7 @@ jobs:
           fi
 
           # Check 4: Checkboxes
-          if ! echo "$DESCRIPTION" | grep -qF '- [ ]'; then
+          if ! echo "$DESCRIPTION" | grep -qF -- '- [ ]'; then
             FAILURES="${FAILURES}\n- Acceptance criteria has no \`- [ ]\` checkboxes"
           fi
 


### PR DESCRIPTION
## Problem
`grep -qF '- [ ]'` crashes with `invalid option -- ' '` on GNU grep — the leading dash-space is parsed as an option flag. This causes false-positive CI failures on Check 4 even for valid tickets with checkboxes. Same fix applied to android-app and chat-api repos.

## Fix
Added `--` before the pattern: `grep -qF -- '- [ ]'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)