### PR TITLE
feat: pipeline monitor + ticket quality gate (AMA-687)

### DIFF
--- a/.github/workflows/pipeline-monitor.yml
+++ b/.github/workflows/pipeline-monitor.yml
@@ -31,7 +31,7 @@ jobs:
           ACTIVE_TABLE=""
           STUCK_LIST=""
           TODAY=$(date +%Y-%m-%d)
-          CUTOFF=$(date -d '24 hours ago' --iso-8601=seconds 2>/dev/null || date -v-24H -u +%Y-%m-%dT%H:%M:%SZ)
+          CUTOFF=$(date -d '48 hours ago' --iso-8601=seconds 2>/dev/null || date -v-48H -u +%Y-%m-%dT%H:%M:%SZ)
 
           for REPO in "${REPOS[@]}"; do
             # Open PRs with AMA-* branches

--- a/.github/workflows/ticket-quality-gate.yml
+++ b/.github/workflows/ticket-quality-gate.yml
@@ -25,7 +25,7 @@ jobs:
 
           # Fetch Todo tickets
           QUERY=$(cat <<'GRAPHQL'
-{"query": "{ issues(filter: { state: { type: { eq: \"unstarted\" } }, team: { name: { eq: \"MyAmaka\" } } }, first: 50) { nodes { identifier title description url } } }"}
+{"query": "{ issues(filter: { state: { type: { eq: \"unstarted\" } }, team: { name: { eq: \"MyAmaka\" } } }, first: 250) { nodes { identifier title description url } } }"}
 GRAPHQL
 )
 


### PR DESCRIPTION
## Summary
- Adds `pipeline-monitor.yml`: daily GitHub Issue showing all active Antfarm pipelines (open AMA-* PRs + stuck branches with no PR >24h). Runs 09:00 UTC daily + `workflow_dispatch`.
- Adds `ticket-quality-gate.yml`: nightly scan for Linear Todo tickets missing `## Acceptance Criteria`. Posts a GitHub Issue listing them. Runs 23:00 UTC + `workflow_dispatch`.

## Prerequisites
Both workflows require:
- `GH_PAT` secret (already set for branch-orphan-checker) ✓
- `LINEAR_API_KEY` secret — add if not already present

## Test plan
- [ ] Trigger `pipeline-monitor.yml` manually via workflow_dispatch → GitHub Issue created
- [ ] Trigger `ticket-quality-gate.yml` manually via workflow_dispatch → Issue lists any sparse tickets

Resolves [AMA-687](https://linear.app/amakaflow/issue/AMA-687)